### PR TITLE
Add API routes and Prisma schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "next": "15.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-redux": "^9.2.0"
+    "react-redux": "^9.2.0",
+    "@prisma/client": "^5.12.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -27,6 +28,7 @@
     "eslint-config-next": "15.3.4",
     "tailwindcss": "^4",
     "tailwindcss-rtl": "^0.9.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "prisma": "^5.12.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,60 @@
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Question {
+  id                String   @id @default(uuid())
+  body              String
+  answers           String   // JSON stringified array
+  rightAnswerIndex  Int
+  answerExplanation String
+  categories        Category[]
+  difficulties      Difficulty[]
+  score             Int
+  quiz              Quiz?   @relation(fields: [quizId], references: [id])
+  quizId            String?
+}
+
+model Quiz {
+  id                String   @id @default(uuid())
+  title             String
+  categories        Category[]
+  difficulties      Difficulty[]
+  numberOfQuestions Int
+  questions         Question[]
+  quizUsers         QuizUser[]
+}
+
+model QuizUser {
+  id       String @id @default(uuid())
+  userId   String
+  username String
+  score    Int
+  quiz     Quiz   @relation(fields: [quizId], references: [id])
+  quizId   String
+}
+
+model Category {
+  id        String     @id @default(uuid())
+  name      String
+  questions Question[]
+  quizzes   Quiz[]
+}
+
+model Difficulty {
+  id        String     @id @default(uuid())
+  name      String
+  questions Question[]
+  quizzes   Quiz[]
+}
+
+model Admin {
+  id       String @id @default(uuid())
+  username String @unique
+  password String
+}

--- a/src/app/api/admin/route.ts
+++ b/src/app/api/admin/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+
+export async function POST(request: Request) {
+  const data = await request.json()
+  const admin = await prisma.admin.create({ data })
+  return NextResponse.json(admin)
+}
+
+export async function GET() {
+  const admins = await prisma.admin.findMany()
+  return NextResponse.json(admins)
+}

--- a/src/app/api/category/route.ts
+++ b/src/app/api/category/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+
+export async function POST(request: Request) {
+  const data = await request.json()
+  const category = await prisma.category.create({ data })
+  return NextResponse.json(category)
+}
+
+export async function GET() {
+  const categories = await prisma.category.findMany()
+  return NextResponse.json(categories)
+}

--- a/src/app/api/difficulty/route.ts
+++ b/src/app/api/difficulty/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+
+export async function POST(request: Request) {
+  const data = await request.json()
+  const difficulty = await prisma.difficulty.create({ data })
+  return NextResponse.json(difficulty)
+}
+
+export async function GET() {
+  const difficulties = await prisma.difficulty.findMany()
+  return NextResponse.json(difficulties)
+}

--- a/src/app/api/question/route.ts
+++ b/src/app/api/question/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+
+export async function POST(request: Request) {
+  const data = await request.json()
+  const question = await prisma.question.create({ data })
+  return NextResponse.json(question)
+}
+
+export async function GET() {
+  const questions = await prisma.question.findMany()
+  return NextResponse.json(questions)
+}

--- a/src/app/api/quiz-user/route.ts
+++ b/src/app/api/quiz-user/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+
+export async function GET() {
+  const quizUsers = await prisma.quizUser.findMany()
+  return NextResponse.json(quizUsers)
+}

--- a/src/app/api/quiz/route.ts
+++ b/src/app/api/quiz/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+
+export async function POST(request: Request) {
+  const data = await request.json()
+  const quiz = await prisma.quiz.create({ data })
+  return NextResponse.json(quiz)
+}
+
+export async function GET() {
+  const quizzes = await prisma.quiz.findMany({ include: { questions: true } })
+  return NextResponse.json(quizzes)
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient }
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({
+    log: ['query'],
+  })
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+
+export default prisma


### PR DESCRIPTION
## Summary
- set up Prisma with SQLite database
- add Prisma client helper
- create API routes for admin, category, difficulty, question, quiz, and quiz-user
- update dependencies to include Prisma

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a736fcd883279b3f46d0b3db0691