### PR TITLE
Add Prisma schema and API routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="file:./dev.db"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@reduxjs/toolkit": "^2.8.2",
     "axios": "^1.10.0",
     "clsx": "^2.1.1",
+    "@prisma/client": "^5.14.0",
     "next": "15.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -25,6 +26,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
+    "prisma": "^5.14.0",
     "tailwindcss": "^4",
     "tailwindcss-rtl": "^0.9.0",
     "typescript": "^5"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,54 @@
+// Prisma schema
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Question {
+  id               String @id @default(uuid())
+  body             String
+  answers          Json
+  rightAnswerIndex Int
+  answerExplanation String
+  categories       Json
+  difficulties     Json
+  score            Int
+}
+
+model Quiz {
+  id                String    @id @default(uuid())
+  title             String
+  categories        Json
+  difficulties      Json
+  numberOfQuestions Int
+  QuizUser          QuizUser[]
+}
+
+model QuizUser {
+  id       String @id @default(uuid())
+  username String
+  score    Int
+  quizId   String
+  quiz     Quiz   @relation(fields: [quizId], references: [id])
+}
+
+model Category {
+  id   String @id @default(uuid())
+  name String
+}
+
+model Difficulty {
+  id   String @id @default(uuid())
+  name String
+}
+
+model Admin {
+  id       String @id @default(uuid())
+  username String
+  password String
+}

--- a/src/app/api/admins/route.ts
+++ b/src/app/api/admins/route.ts
@@ -1,0 +1,19 @@
+import prisma from '@/lib/prisma'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get('id')
+  if (id) {
+    const admin = await prisma.admin.findUnique({ where: { id } })
+    return NextResponse.json(admin)
+  }
+  const admins = await prisma.admin.findMany()
+  return NextResponse.json(admins)
+}
+
+export async function POST(request: NextRequest) {
+  const data = await request.json()
+  const admin = await prisma.admin.create({ data })
+  return NextResponse.json(admin)
+}

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,0 +1,19 @@
+import prisma from '@/lib/prisma'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get('id')
+  if (id) {
+    const category = await prisma.category.findUnique({ where: { id } })
+    return NextResponse.json(category)
+  }
+  const categories = await prisma.category.findMany()
+  return NextResponse.json(categories)
+}
+
+export async function POST(request: NextRequest) {
+  const data = await request.json()
+  const category = await prisma.category.create({ data })
+  return NextResponse.json(category)
+}

--- a/src/app/api/difficulties/route.ts
+++ b/src/app/api/difficulties/route.ts
@@ -1,0 +1,19 @@
+import prisma from '@/lib/prisma'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get('id')
+  if (id) {
+    const difficulty = await prisma.difficulty.findUnique({ where: { id } })
+    return NextResponse.json(difficulty)
+  }
+  const difficulties = await prisma.difficulty.findMany()
+  return NextResponse.json(difficulties)
+}
+
+export async function POST(request: NextRequest) {
+  const data = await request.json()
+  const difficulty = await prisma.difficulty.create({ data })
+  return NextResponse.json(difficulty)
+}

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -1,0 +1,19 @@
+import prisma from '@/lib/prisma'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get('id')
+  if (id) {
+    const question = await prisma.question.findUnique({ where: { id } })
+    return NextResponse.json(question)
+  }
+  const questions = await prisma.question.findMany()
+  return NextResponse.json(questions)
+}
+
+export async function POST(request: NextRequest) {
+  const data = await request.json()
+  const question = await prisma.question.create({ data })
+  return NextResponse.json(question)
+}

--- a/src/app/api/quiz-users/route.ts
+++ b/src/app/api/quiz-users/route.ts
@@ -1,0 +1,19 @@
+import prisma from '@/lib/prisma'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get('id')
+  if (id) {
+    const quizUser = await prisma.quizUser.findUnique({ where: { id } })
+    return NextResponse.json(quizUser)
+  }
+  const quizUsers = await prisma.quizUser.findMany()
+  return NextResponse.json(quizUsers)
+}
+
+export async function POST(request: NextRequest) {
+  const data = await request.json()
+  const quizUser = await prisma.quizUser.create({ data })
+  return NextResponse.json(quizUser)
+}

--- a/src/app/api/quizzes/route.ts
+++ b/src/app/api/quizzes/route.ts
@@ -1,0 +1,19 @@
+import prisma from '@/lib/prisma'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get('id')
+  if (id) {
+    const quiz = await prisma.quiz.findUnique({ where: { id } })
+    return NextResponse.json(quiz)
+  }
+  const quizzes = await prisma.quiz.findMany()
+  return NextResponse.json(quizzes)
+}
+
+export async function POST(request: NextRequest) {
+  const data = await request.json()
+  const quiz = await prisma.quiz.create({ data })
+  return NextResponse.json(quiz)
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,10 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient }
+
+export const prisma =
+  globalForPrisma.prisma || new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+
+export default prisma


### PR DESCRIPTION
## Summary
- setup Prisma schema for quiz app
- expose Prisma instance
- implement REST-like API routes for create/get on all tables
- add example `.env`
- include prisma dependencies

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867bb8c957c8327a57347ca06b83209