### PR TITLE
Add Prisma schema and API routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example SQLite configuration
+DATABASE_URL="file:./dev.db"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "next": "15.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-redux": "^9.2.0"
+    "react-redux": "^9.2.0",
+    "@prisma/client": "^5.12.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -27,6 +28,7 @@
     "eslint-config-next": "15.3.4",
     "tailwindcss": "^4",
     "tailwindcss-rtl": "^0.9.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "prisma": "^5.12.1"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,101 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite" // or postgresql/mysql
+  url      = env("DATABASE_URL")
+}
+
+model Question {
+  id                 String               @id @default(uuid())
+  body               String
+  answers            String[]
+  rightAnswerIndex   Int
+  answerExplanation  String
+  score              Int
+
+  questionCategories QuestionCategory[]
+  questionDifficulties QuestionDifficulty[]
+}
+
+model Quiz {
+  id               String            @id @default(uuid())
+  title            String
+  numberOfQuestions Int
+
+  quizCategories   QuizCategory[]
+  quizDifficulties QuizDifficulty[]
+  users            QuizUser[]
+}
+
+model QuizUser {
+  id       String @id @default(uuid())
+  quizId   String
+  username String
+  score    Int
+
+  quiz     Quiz   @relation(fields: [quizId], references: [id])
+}
+
+model Category {
+  id                 String             @id @default(uuid())
+  name               String             @unique
+
+  questionCategories QuestionCategory[]
+  quizCategories     QuizCategory[]
+}
+
+model Difficulty {
+  id                  String               @id @default(uuid())
+  name                String               @unique
+
+  questionDifficulties QuestionDifficulty[]
+  quizDifficulties     QuizDifficulty[]
+}
+
+model Admin {
+  id       String @id @default(uuid())
+  username String @unique
+  password String
+}
+
+model QuestionCategory {
+  questionId String
+  categoryId String
+
+  question   Question @relation(fields: [questionId], references: [id])
+  category   Category @relation(fields: [categoryId], references: [id])
+
+  @@id([questionId, categoryId])
+}
+
+model QuizCategory {
+  quizId     String
+  categoryId String
+
+  quiz       Quiz     @relation(fields: [quizId], references: [id])
+  category   Category @relation(fields: [categoryId], references: [id])
+
+  @@id([quizId, categoryId])
+}
+
+model QuestionDifficulty {
+  questionId   String
+  difficultyId String
+
+  question     Question   @relation(fields: [questionId], references: [id])
+  difficulty   Difficulty @relation(fields: [difficultyId], references: [id])
+
+  @@id([questionId, difficultyId])
+}
+
+model QuizDifficulty {
+  quizId        String
+  difficultyId  String
+
+  quiz          Quiz       @relation(fields: [quizId], references: [id])
+  difficulty    Difficulty @relation(fields: [difficultyId], references: [id])
+
+  @@id([quizId, difficultyId])
+}

--- a/src/app/api/admins/route.ts
+++ b/src/app/api/admins/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+  const username = searchParams.get("username");
+
+  try {
+    const admins = await prisma.admin.findMany({
+      where: {
+        ...(id && { id }),
+        ...(username && { username }),
+      },
+    });
+
+    const formatted = admins.map((admin) => ({
+      id: admin.id,
+      username: admin.username,
+      password: admin.password,
+    }));
+
+    return NextResponse.json(formatted, { status: 200 });
+  } catch (error) {
+    console.error("Error fetching admins:", error);
+    return NextResponse.json({ error: "Failed to fetch admins" }, { status: 500 });
+  }
+}

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+  const name = searchParams.get("name");
+
+  try {
+    const categories = await prisma.category.findMany({
+      where: {
+        ...(id && { id }),
+        ...(name && { name: { contains: name, mode: "insensitive" } }),
+      },
+    });
+
+    const formatted = categories.map((c) => ({ id: c.id, name: c.name }));
+
+    return NextResponse.json(formatted, { status: 200 });
+  } catch (error) {
+    console.error("Error fetching categories:", error);
+    return NextResponse.json({ error: "Failed to fetch categories" }, { status: 500 });
+  }
+}

--- a/src/app/api/difficulties/route.ts
+++ b/src/app/api/difficulties/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+  const name = searchParams.get("name");
+
+  try {
+    const difficulties = await prisma.difficulty.findMany({
+      where: {
+        ...(id && { id }),
+        ...(name && { name: { contains: name, mode: "insensitive" } }),
+      },
+    });
+
+    const formatted = difficulties.map((d) => ({ id: d.id, name: d.name }));
+
+    return NextResponse.json(formatted, { status: 200 });
+  } catch (error) {
+    console.error("Error fetching difficulties:", error);
+    return NextResponse.json({ error: "Failed to fetch difficulties" }, { status: 500 });
+  }
+}

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+  const categories = searchParams.get("categories")?.split(",");
+  const difficulties = searchParams.get("difficulties")?.split(",");
+
+  try {
+    const questions = await prisma.question.findMany({
+      where: {
+        ...(id && { id }),
+        ...(categories && categories.length > 0 && {
+          questionCategories: {
+            some: {
+              category: {
+                name: { in: categories },
+              },
+            },
+          },
+        }),
+        ...(difficulties && difficulties.length > 0 && {
+          questionDifficulties: {
+            some: {
+              difficulty: {
+                name: { in: difficulties },
+              },
+            },
+          },
+        }),
+      },
+      include: {
+        questionCategories: { include: { category: true } },
+        questionDifficulties: { include: { difficulty: true } },
+      },
+    });
+
+    const formatted = questions.map((q) => ({
+      id: q.id,
+      body: q.body,
+      answers: q.answers,
+      rightAnswerIndex: q.rightAnswerIndex,
+      answerExplanation: q.answerExplanation,
+      score: q.score,
+      categories: q.questionCategories.map((qc) => ({
+        id: qc.category.id,
+        name: qc.category.name,
+      })),
+      difficulties: q.questionDifficulties.map((qd) => ({
+        id: qd.difficulty.id,
+        name: qd.difficulty.name,
+      })),
+    }));
+
+    return NextResponse.json(formatted, { status: 200 });
+  } catch (error) {
+    console.error("Error fetching questions:", error);
+    return NextResponse.json({ error: "Failed to fetch questions" }, { status: 500 });
+  }
+}

--- a/src/app/api/quiz-users/route.ts
+++ b/src/app/api/quiz-users/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+  const quizId = searchParams.get("quizId");
+  const username = searchParams.get("username");
+
+  try {
+    const quizUsers = await prisma.quizUser.findMany({
+      where: {
+        ...(id && { id }),
+        ...(quizId && { quizId }),
+        ...(username && { username }),
+      },
+      include: {
+        quiz: true,
+      },
+    });
+
+    const formatted = quizUsers.map((user) => ({
+      id: user.id,
+      username: user.username,
+      score: user.score,
+      quiz: {
+        id: user.quiz.id,
+        title: user.quiz.title,
+        numberOfQuestions: user.quiz.numberOfQuestions,
+      },
+    }));
+
+    return NextResponse.json(formatted, { status: 200 });
+  } catch (error) {
+    console.error("Error fetching quiz users:", error);
+    return NextResponse.json({ error: "Failed to fetch quiz users" }, { status: 500 });
+  }
+}

--- a/src/app/api/quizzes/route.ts
+++ b/src/app/api/quizzes/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+  const categories = searchParams.get("categories")?.split(",");
+  const difficulties = searchParams.get("difficulties")?.split(",");
+
+  try {
+    const quizzes = await prisma.quiz.findMany({
+      where: {
+        ...(id && { id }),
+        ...(categories && categories.length > 0 && {
+          quizCategories: {
+            some: {
+              category: {
+                name: { in: categories },
+              },
+            },
+          },
+        }),
+        ...(difficulties && difficulties.length > 0 && {
+          quizDifficulties: {
+            some: {
+              difficulty: {
+                name: { in: difficulties },
+              },
+            },
+          },
+        }),
+      },
+      include: {
+        quizCategories: { include: { category: true } },
+        quizDifficulties: { include: { difficulty: true } },
+      },
+    });
+
+    const formatted = quizzes.map((quiz) => ({
+      id: quiz.id,
+      title: quiz.title,
+      numberOfQuestions: quiz.numberOfQuestions,
+      categories: quiz.quizCategories.map((qc) => ({
+        id: qc.category.id,
+        name: qc.category.name,
+      })),
+      difficulties: quiz.quizDifficulties.map((qd) => ({
+        id: qd.difficulty.id,
+        name: qd.difficulty.name,
+      })),
+    }));
+
+    return NextResponse.json(formatted, { status: 200 });
+  } catch (error) {
+    console.error("Error fetching quizzes:", error);
+    return NextResponse.json({ error: "Failed to fetch quizzes" }, { status: 500 });
+  }
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,10 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined };
+
+export const prisma =
+  globalForPrisma.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+
+export default prisma;


### PR DESCRIPTION
## Summary
- add `.env.example` with database url
- allow committing `.env.example`
- install Prisma dependencies
- add Prisma schema
- provide a shared Prisma client
- create API routes for questions, quizzes, categories, difficulties, quiz users and admins

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867fddff6588327b92c0906e6a02724